### PR TITLE
add pending status on creation instead of running and allow reporting…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-common",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "common modules for codefresh runtime and api",
   "main": "index.js",
   "scripts": {

--- a/taskLogger/taskLogger.unit.spec.js
+++ b/taskLogger/taskLogger.unit.spec.js
@@ -347,6 +347,17 @@ describe('taskLogger tests', function () {
             stepLogger.getLastUpdateReference();
         });
 
+        it('3.11 trigger start handler', function(){
+
+            var Firebase = createMockFirebase();
+            var Logger     = createMockLogger();
+            var logger = new Logger("progress_id", null, "firebaseUrl", Firebase);
+            var stepLogger = logger.create("step1");
+            expect(stepLogger.getStatus()).to.equal('pending');
+            stepLogger.start();
+            expect(stepLogger.getStatus()).to.equal('running');
+        });
+
     });
 
     describe('4 using handlers after step was finished', function(){
@@ -430,6 +441,20 @@ describe('taskLogger tests', function () {
             stepLogger.finish();
         });
 
+        it('4.8 should emit an error when triggering start handler after a step has finished', function(done){
+            var Firebase = createMockFirebase();
+            var Logger     = createMockLogger();
+            var logger = new Logger("progress_id", null, "firebaseUrl", Firebase);
+            var stepLogger = logger.create("step1");
+            logger.on("error", function(err){
+                expect(err.toString()).to.contain("was triggered when the step status is: success");
+                expect(err.toString()).to.not.contain("with err");
+                done();
+            });
+            stepLogger.finish();
+            stepLogger.start();
+        });
+
     });
 
     describe('5 fatalError', function() {
@@ -485,7 +510,7 @@ describe('taskLogger tests', function () {
             });
 
         });
-        
+
     });
-    
+
 });


### PR DESCRIPTION
… skipped steps

now when a step will be created it will be in pending mode.
this will allow us to still write logs to the step, but not have it in running mode.

in order to mark a step as running it should be done explicitly.

added ability to report skipped steps with a new `skipped` status